### PR TITLE
Fix analyser warnings

### DIFF
--- a/PopoverView/PopoverView.m
+++ b/PopoverView/PopoverView.m
@@ -407,7 +407,7 @@
     NSAssert((stringArray.count == imageArray.count), @"stringArray.count should equal imageArray.count");
     NSMutableArray* tempViewArray = [self makeTempViewsWithStrings:stringArray andImages:imageArray];
     
-    [self showAtPoint:point inView:view withViewArray:[tempViewArray autorelease]];
+    [self showAtPoint:point inView:view withViewArray:tempViewArray];
 }
 
 - (void)showAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withStringArray:(NSArray *)stringArray withImageArray:(NSArray *)imageArray
@@ -415,7 +415,7 @@
     NSAssert((stringArray.count == imageArray.count), @"stringArray.count should equal imageArray.count");
     NSMutableArray* tempViewArray = [self makeTempViewsWithStrings:stringArray andImages:imageArray];
         
-    [self showAtPoint:point inView:view withTitle:title withViewArray:[tempViewArray autorelease]];
+    [self showAtPoint:point inView:view withTitle:title withViewArray:tempViewArray];
 }
 
 - (NSMutableArray*) makeTempViewsWithStrings:(NSArray *)stringArray andImages:(NSArray *)imageArray
@@ -463,7 +463,7 @@
         [containerView release];
     }
 
-    return tempViewArray;
+    return [tempViewArray autorelease];
 }
 
 - (void)showAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withContentView:(UIView *)cView


### PR DESCRIPTION
The `makeTempViewsWithStrings:andImages:` method does not conform to naming conventions (methods that return a retained object should start with `init`, `new`, `copy` etc). This causes the Analyser to identify a memory leak when returning `tempViewArray`.

For reference:
http://developer.apple.com/library/ios/#documentation/cocoa/conceptual/ProgrammingWithObjectiveC/Conventions/Conventions.html%23//apple_ref/doc/uid/TP40011210-CH10-SW9

http://developer.apple.com/library/ios/#documentation/cocoa/conceptual/MemoryMgmt/Articles/mmRules.html%23//apple_ref/doc/uid/20000994-SW1
