### PR TITLE
Added support for a border with a given color and width

### DIFF
--- a/PopoverView/PopoverView.m
+++ b/PopoverView/PopoverView.m
@@ -1035,6 +1035,15 @@
             }
         }
     }
+    
+    //Draw border if we need to
+    //The border is done last because it needs to be drawn on top of everything else
+    if (kDrawBorder) {
+        [kBorderColor setStroke];
+        popoverPath.lineWidth = kBorderWidth;
+        [popoverPath stroke];
+    }
+    
 }
 
 @end

--- a/PopoverView/PopoverView_Configuration.h
+++ b/PopoverView/PopoverView_Configuration.h
@@ -98,3 +98,15 @@
 
 //title text color
 #define kTitleColor [UIColor colorWithRed:0.329 green:0.341 blue:0.353 alpha:1]
+
+
+// BORDER
+
+//bool that turns off/on the border
+#define kDrawBorder NO
+
+//border color
+#define kBorderColor [UIColor blackColor]
+
+//border width
+#define kBorderWidth 1.f


### PR DESCRIPTION
Hi Oliver

Thanks for putting this popover together. I needed a border for it, so here it is.  
The change is straightforward, basically I use the UIBezierPath stroke after all other elements are drawn.     

I have created three constants to show the border (default to NO). set the color and set the width.

Here is what it looks like:

![popoverWithBorder](https://f.cloud.github.com/assets/1455711/267581/90aeb844-8ea1-11e2-8b32-f7dcdb32f17e.png)

Cheers

David 
