### PR TITLE
Basic support for NSAttributedStrings and removed iOS6 warnings

### DIFF
--- a/PopoverView/PopoverView.h
+++ b/PopoverView/PopoverView.h
@@ -160,6 +160,9 @@
 //This method does same as above, but with a title label at the top of the popover.
 - (void)showAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withStringArray:(NSArray *)stringArray;
 
+//This method does same as above, but with a title label at the top of the popover and with a list of attributed strings
+- (void)showAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withAttributedStringArray:(NSArray *)stringArray;
+
 //Draws a vertical list of the NSString elements of stringArray with UIImages
 //from imageArray placed centered above them.
 - (void)showAtPoint:(CGPoint)point inView:(UIView *)view withStringArray:(NSArray *)stringArray withImageArray:(NSArray *)imageArray;

--- a/PopoverView/PopoverView.h
+++ b/PopoverView/PopoverView.h
@@ -125,6 +125,8 @@
 
 + (PopoverView *)showPopoverAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withStringArray:(NSArray *)stringArray delegate:(id<PopoverViewDelegate>)delegate;
 
++ (PopoverView *)showPopoverAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withAttributedStringArray:(NSArray *)stringArray delegate:(id<PopoverViewDelegate>)delegate;
+
 + (PopoverView *)showPopoverAtPoint:(CGPoint)point inView:(UIView *)view withStringArray:(NSArray *)stringArray withImageArray:(NSArray *)imageArray delegate:(id<PopoverViewDelegate>)delegate;
 
 + (PopoverView *)showPopoverAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withStringArray:(NSArray *)stringArray withImageArray:(NSArray *)imageArray delegate:(id<PopoverViewDelegate>)delegate;

--- a/PopoverView/PopoverView.m
+++ b/PopoverView/PopoverView.m
@@ -161,7 +161,7 @@
     UIFont *font = kTextFont;
     
     CGSize screenSize = [self screenSize];
-    CGSize textSize = [text sizeWithFont:font constrainedToSize:CGSizeMake(screenSize.width - kHorizontalMargin*4.f, 1000.f) lineBreakMode:UILineBreakModeWordWrap];
+    CGSize textSize = [text sizeWithFont:font constrainedToSize:CGSizeMake(screenSize.width - kHorizontalMargin*4.f, 1000.f) lineBreakMode:NSLineBreakByWordWrapping];
     
     UILabel *textView = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, textSize.width, textSize.height)];
     textView.backgroundColor = [UIColor clearColor];
@@ -180,7 +180,7 @@
     UIFont *font = kTextFont;
     
     CGSize screenSize = [self screenSize];
-    CGSize textSize = [text sizeWithFont:font constrainedToSize:CGSizeMake(screenSize.width - kHorizontalMargin*4.f, 1000.f) lineBreakMode:UILineBreakModeWordWrap];
+    CGSize textSize = [text sizeWithFont:font constrainedToSize:CGSizeMake(screenSize.width - kHorizontalMargin*4.f, 1000.f) lineBreakMode:NSLineBreakByWordWrapping];
     
     UILabel *textView = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, textSize.width, textSize.height)];
     textView.backgroundColor = [UIColor clearColor];
@@ -273,7 +273,7 @@
     UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0.f, 0.f, titleSize.width, titleSize.height)];
     titleLabel.backgroundColor = [UIColor clearColor];
     titleLabel.font = kTitleFont;
-    titleLabel.textAlignment = UITextAlignmentCenter;
+    titleLabel.textAlignment = kTextAlignment;
     titleLabel.textColor = kTitleColor;
     titleLabel.text = title;
     

--- a/PopoverView/PopoverView.m
+++ b/PopoverView/PopoverView.m
@@ -69,6 +69,15 @@
     return popoverView;
 }
 
++ (PopoverView *)showPopoverAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withAttributedStringArray:(NSArray *)stringArray delegate:(id<PopoverViewDelegate>)delegate
+{
+	PopoverView *popoverView = [[PopoverView alloc] initWithFrame:CGRectZero];
+    [popoverView showAtPoint:point inView:view withTitle:title withAttributedStringArray:stringArray];
+    popoverView.delegate = delegate;
+    [popoverView RELEASE];
+    return popoverView;
+}
+
 + (PopoverView *)showPopoverAtPoint:(CGPoint)point inView:(UIView *)view withStringArray:(NSArray *)stringArray withImageArray:(NSArray *)imageArray delegate:(id<PopoverViewDelegate>)delegate {
     PopoverView *popoverView = [[PopoverView alloc] initWithFrame:CGRectZero];
     [popoverView showAtPoint:point inView:view withStringArray:stringArray withImageArray:imageArray];
@@ -388,6 +397,31 @@
         textButton.titleLabel.textAlignment = kTextAlignment;
         textButton.titleLabel.textColor = kTextColor;
         [textButton setTitle:string forState:UIControlStateNormal];
+        textButton.layer.cornerRadius = 4.f;
+        [textButton setTitleColor:kTextColor forState:UIControlStateNormal];
+        [textButton setTitleColor:kTextHighlightColor forState:UIControlStateHighlighted];
+        [textButton addTarget:self action:@selector(didTapButton:) forControlEvents:UIControlEventTouchUpInside];
+        
+        [labelArray addObject:[textButton AUTORELEASE]];
+    }
+    
+    [self showAtPoint:point inView:view withTitle:title withViewArray:[labelArray AUTORELEASE]];
+}
+
+- (void)showAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withAttributedStringArray:(NSArray *)stringArray
+{
+	NSMutableArray *labelArray = [[NSMutableArray alloc] initWithCapacity:stringArray.count];
+    
+    UIFont *font = kTextFont;
+    
+    for (NSAttributedString *attributedString in stringArray) {
+        CGSize textSize = [attributedString.string sizeWithFont:font];
+        UIButton *textButton = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, textSize.width, textSize.height)];
+        textButton.backgroundColor = [UIColor clearColor];
+        textButton.titleLabel.font = font;
+        textButton.titleLabel.textAlignment = kTextAlignment;
+        textButton.titleLabel.textColor = kTextColor;
+		[textButton setAttributedTitle:attributedString forState:UIControlStateNormal];
         textButton.layer.cornerRadius = 4.f;
         [textButton setTitleColor:kTextColor forState:UIControlStateNormal];
         [textButton setTitleColor:kTextHighlightColor forState:UIControlStateHighlighted];

--- a/PopoverView/PopoverView.m
+++ b/PopoverView/PopoverView.m
@@ -170,7 +170,7 @@
     UIFont *font = kTextFont;
     
     CGSize screenSize = [self screenSize];
-    CGSize textSize = [text sizeWithFont:font constrainedToSize:CGSizeMake(screenSize.width - kHorizontalMargin*4.f, 1000.f) lineBreakMode:NSLineBreakByWordWrapping];
+    CGSize textSize = [text sizeWithFont:font constrainedToSize:CGSizeMake(screenSize.width - kHorizontalMargin*4.f, 1000.f) lineBreakMode:kTextLineBreakMode];
     
     UILabel *textView = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, textSize.width, textSize.height)];
     textView.backgroundColor = [UIColor clearColor];
@@ -189,7 +189,7 @@
     UIFont *font = kTextFont;
     
     CGSize screenSize = [self screenSize];
-    CGSize textSize = [text sizeWithFont:font constrainedToSize:CGSizeMake(screenSize.width - kHorizontalMargin*4.f, 1000.f) lineBreakMode:NSLineBreakByWordWrapping];
+    CGSize textSize = [text sizeWithFont:font constrainedToSize:CGSizeMake(screenSize.width - kHorizontalMargin*4.f, 1000.f) lineBreakMode:kTextLineBreakMode];
     
     UILabel *textView = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, textSize.width, textSize.height)];
     textView.backgroundColor = [UIColor clearColor];

--- a/PopoverView/PopoverView_Configuration.h
+++ b/PopoverView/PopoverView_Configuration.h
@@ -90,8 +90,14 @@
 // highlighted text color
 #define kTextHighlightColor [UIColor colorWithRed:0.098 green:0.102 blue:0.106 alpha:1.000]
 
-//normal text alignment
-#define kTextAlignment NSTextAlignmentCenter
+//normal text alignment and word wrapping
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
+#define kTextAlignment		NSTextAlignmentCenter
+#define kTextLineBreakMode	NSLineBreakByWordWrapping
+#else
+#define kTextAlignment		UITextAlignmentCenter
+#define kTextLineBreakMode	UILineBreakModeWordWrap
+#endif
 
 //title font
 #define kTitleFont [UIFont fontWithName:@"HelveticaNeue-Bold" size:16.f]

--- a/PopoverView/PopoverView_Configuration.h
+++ b/PopoverView/PopoverView_Configuration.h
@@ -91,7 +91,7 @@
 #define kTextHighlightColor [UIColor colorWithRed:0.098 green:0.102 blue:0.106 alpha:1.000]
 
 //normal text alignment
-#define kTextAlignment UITextAlignmentCenter
+#define kTextAlignment NSTextAlignmentCenter
 
 //title font
 #define kTitleFont [UIFont fontWithName:@"HelveticaNeue-Bold" size:16.f]


### PR DESCRIPTION
Added a simple, new method (below) to add support for NSAttributedStrings. Also added conditionals to remove iOS6 warnings from using UITextAlignmentCenter and UILineBreakModeWordWrap.
- (PopoverView *)showPopoverAtPoint:(CGPoint)point inView:(UIView *)view withTitle:(NSString *)title withAttributedStringArray:(NSArray *)stringArray delegate:(id<PopoverViewDelegate>)delegate;
