### PR TITLE
Fixed an error on arm64

### DIFF
--- a/PopoverView/PopoverView.m
+++ b/PopoverView/PopoverView.m
@@ -797,7 +797,7 @@
 
 - (void)didTapButton:(UIButton *)sender
 {
-    int index = [subviewsArray indexOfObject:sender];
+    NSUInteger index = [subviewsArray indexOfObject:sender];
     
     if (index == NSNotFound) {
         return;


### PR DESCRIPTION
On the arm64 platform the comparison with NSNotFound will fail, because it's no longer in the range of int
