### PR TITLE
reset transform after dismiss

### DIFF
--- a/PopoverView/PopoverView.m
+++ b/PopoverView/PopoverView.m
@@ -825,6 +825,7 @@
             self.alpha = 0.1f;
             self.transform = CGAffineTransformMakeScale(0.1f, 0.1f);
         } completion:^(BOOL finished) {
+            self.transform = CGAffineTransformIdentity;
             [self dismissComplete];
         }];
     }


### PR DESCRIPTION
If I keep the popover object as a property, after I dismiss it, the frame of the popover object will be 10x of before when I show it again. So we should reset the transform after dismiss, then it will work perfectly when show again.