### PR TITLE
Improved dismiss

### DIFF
--- a/PopoverView/PopoverView.m
+++ b/PopoverView/PopoverView.m
@@ -833,11 +833,11 @@
 
 - (void)dismissComplete
 {
-    [self removeFromSuperview];
-    
     if (self.delegate && [self.delegate respondsToSelector:@selector(popoverViewDidDismiss:)]) {
         [delegate popoverViewDidDismiss:self];
     }
+
+    [self removeFromSuperview];
 }
 
 - (void)animateRotationToNewPoint:(CGPoint)point inView:(UIView *)view withDuration:(NSTimeInterval)duration


### PR DESCRIPTION
This way, the delegate method is called before removing from superview and it allows subviews to dismiss keyboards or other input methods.
